### PR TITLE
Update datastore storage format

### DIFF
--- a/lib/document_handler.js
+++ b/lib/document_handler.js
@@ -16,22 +16,24 @@ var DocumentHandler = function(options) {
 
 DocumentHandler.defaultKeyLength = 10;
 
-DocumentHandler.prototype._setStoreObject = function(doc, rawData, response, forStaticDoc) {
+DocumentHandler.prototype._setStoreObject = function(metadata, rawData, response, forStaticDoc) {
   var _this = this;
-  var validateAndStore = function(doc) {
-    var jsonDoc = JSON.stringify(doc);
+  var validateAndStore = function(metadata, b64zipped) {
     // Check length
-    if (_this.maxLength && jsonDoc.length > _this.maxLength) {
+    if (_this.maxLength && b64zipped.length > _this.maxLength) {
       winston.warn('document > maxLength', { maxLength: _this.maxLength });
       response.writeHead(400, { 'content-type': 'application/json' });
       response.end(JSON.stringify({ message: 'Document exceeds maximum length.' }));
       return;
     }
+
     // And then save if we should
     _this.chooseKey(function (key) {
       // static documents are linked via static key/name rather than some generated key
-      if (forStaticDoc) key = doc.name;
-      _this.store.set(key, jsonDoc, function (res) {
+      if (forStaticDoc) key = metadata.name;
+
+      _this.store.set(key, metadata, b64zipped, function (res) {
+        winston.info('callback from set ');
         if (res) {
           winston.verbose('added document', { key: key });
           response.writeHead(200, { 'content-type': 'application/json' });
@@ -47,15 +49,16 @@ DocumentHandler.prototype._setStoreObject = function(doc, rawData, response, for
 
   zlib.gzip(rawData, function(err, zippedData) {
     if (!err) {
+      var b64zipped = '';
       try {
-        doc.file = zippedData.toString('base64');
+        b64zipped = zippedData.toString('base64');
       } catch (error) {
         winston.error('base64 error', { error: error });
         response.writeHead(500, { 'content-type': 'application/json' });
         response.end(JSON.stringify({ message: 'zlib error' }));
         return;
       }
-      validateAndStore(doc);
+      validateAndStore(metadata, b64zipped);
     } else {
       winston.error('zlib error', { error: err });
       response.writeHead(500, { 'content-type': 'application/json' });
@@ -65,9 +68,9 @@ DocumentHandler.prototype._setStoreObject = function(doc, rawData, response, for
 };
 
 DocumentHandler.prototype._getStoreObject = function(key, skipExpire, response, callback) {
-  this.store.get(key, function(doc) {
-    if (!doc) {
-      winston.warn('document not found', {key: key});
+  this.store.get(key, function(reply) {
+    if (!reply || reply.length != 2) {
+      winston.warn('document not found', { key: key, reply: reply });
       response.writeHead(404, { 'content-type': 'application/json' });
       response.end(JSON.stringify({ message: 'Document not found.' }));
       callback(true);
@@ -75,16 +78,17 @@ DocumentHandler.prototype._getStoreObject = function(key, skipExpire, response, 
     }
 
     winston.verbose('retrieved document', { key: key });
+    var doc = {};
     try {
-      doc = JSON.parse(doc);
+      doc = JSON.parse(reply[0]);
     } catch (err) {
-      winston.error('document not in json format', { key: key });
+      winston.error('document metadata not in json format', { key: key, metadata: reply[0] });
       response.writeHead(500, { 'content-type': 'application/json' });
       response.end(JSON.stringify({ message: 'Error with document' }));
       callback(true);
       return;
     }
-    zlib.gunzip(new Buffer(doc.file, 'base64'), function(err, rawData) {
+    zlib.gunzip(new Buffer(reply[1], 'base64'), function(err, rawData) {
       if (err) {
         winston.error('zlib error', { key: key, error: err });
         response.writeHead(500, { 'content-type': 'application/json' });
@@ -133,11 +137,10 @@ DocumentHandler.prototype.handleGet = function(request, response, skipExpire) {
 DocumentHandler.prototype.handlePost = function (request, response) {
   var _this = this;
 
-  var doc = {
+  var metadata = {
     name: '',
     size: 0,
     mimetype: 'text/plain',
-    file: null
   };
 
   // If we should, parse a form to grab the data
@@ -147,8 +150,8 @@ DocumentHandler.prototype.handlePost = function (request, response) {
     var busboy = new Busboy({ headers: request.headers });
     busboy.on('field', function (fieldname, val) {
       if (fieldname === 'data') {
-        doc.size = val.length;
-        _this._setStoreObject(doc, fieldValue, response);
+        metadata.size = val.length;
+        _this._setStoreObject(metadata, fieldValue, response);
         fieldValue = val;
       }
     });
@@ -159,13 +162,10 @@ DocumentHandler.prototype.handlePost = function (request, response) {
       });
       file.on('end', function() {
         var buffer = Buffer.concat(chunks);
-        var doc = {
-          name: filename,
-          size: buffer.length,
-          mimetype: mimetype,
-          file: null
-        };
-        _this._setStoreObject(doc, buffer, response);
+        metadata.name = filename;
+        metadata.size = buffer.length;
+        metadata.mimetype = mimetype;
+        _this._setStoreObject(metadata, buffer, response);
       });
       file.on('error', function(err) {
         response.writeHead(500, { 'content-type': 'application/json' });
@@ -183,8 +183,8 @@ DocumentHandler.prototype.handlePost = function (request, response) {
     request.on('end', function () {
       if (!cancelled) {
         var buffer = Buffer.concat(chunks);
-        doc.size = buffer.length;
-        _this._setStoreObject(doc, buffer, response);
+        metadata.size = buffer.length;
+        _this._setStoreObject(metadata, buffer, response);
       }
     });
     request.on('error', function (error) {

--- a/lib/document_stores/file.js
+++ b/lib/document_stores/file.js
@@ -21,7 +21,7 @@ FileDocumentStore.md5 = function(str) {
 
 // Save data in a file, key as md5 - since we don't know what we could
 // be passed here
-FileDocumentStore.prototype.set = function(key, data, callback, skipExpire) {
+FileDocumentStore.prototype.set = function(key, info, data, callback, skipExpire) {
   try {
     var _this = this;
     fs.mkdir(this.basePath, '700', function() {

--- a/lib/document_stores/memcached.js
+++ b/lib/document_stores/memcached.js
@@ -25,7 +25,7 @@ MemcachedDocumentStore.connect = function(options) {
 
 // Save file in a key
 MemcachedDocumentStore.prototype.set =
-function(key, data, callback, skipExpire) {
+function(key, info, data, callback, skipExpire) {
   MemcachedDocumentStore.client.set(key, data, function(err, reply) {
     err ? callback(false) : callback(true);
   }, skipExpire ? 0 : this.expire);

--- a/lib/document_stores/postgres.js
+++ b/lib/document_stores/postgres.js
@@ -14,7 +14,7 @@ var PostgresDocumentStore = function (options) {
 PostgresDocumentStore.prototype = {
 
   // Set a given key
-  set: function (key, data, callback, skipExpire) {
+  set: function (key, info, data, callback, skipExpire) {
     var now = Math.floor(new Date().getTime() / 1000);
     var that = this;
     this.safeConnect(function (err, client, done) {

--- a/lib/document_stores/redis.js
+++ b/lib/document_stores/redis.js
@@ -1,12 +1,5 @@
-var redis = require('redis');
+var redis = require('then-redis');
 var winston = require('winston');
-
-// For storing in redis
-// options[type] = redis
-// options[host] - The host to connect to (default localhost)
-// options[port] - The port to connect to (default 5379)
-// options[db] - The db to use (default 0)
-// options[expire] - The time to live for each key set (default never)
 
 var RedisDocumentStore = function(options, client) {
   this.expire = options.expire;
@@ -19,61 +12,76 @@ var RedisDocumentStore = function(options, client) {
   }
 };
 
-// Create a connection according to config
 RedisDocumentStore.connect = function(options) {
   var host = options.host || '127.0.0.1';
   var port = options.port || 6379;
   var index = options.db || 0;
-  RedisDocumentStore.client = redis.createClient(port, host);
-  RedisDocumentStore.client.select(index, function(err, reply) {
-    if (err) {
-      winston.error(
-        'error connecting to redis index ' + index,
-        { error: err }
-      );
-      process.exit(1);
-    }
-    else {
-      winston.info('connected to redis on ' + host + ':' + port + '/' + index);
-    }
-  });
+  RedisDocumentStore.client = redis.createClient({port:port, host:host, database:index});
 };
 
-// Save file in a key
-RedisDocumentStore.prototype.set = function(key, data, callback, skipExpire) {
+RedisDocumentStore.prototype.set = function(key, info, data, callback, skipExpire) {
   var _this = this;
-  RedisDocumentStore.client.set(key, data, function(err, reply) {
-    if (err) {
+  var infoJson = JSON.stringify(info);
+  RedisDocumentStore.client.mset('info.'+key, infoJson, 'data.'+key, data).then(function(reply) {
+    if (!reply) {
       callback(false);
+      return;
+    }
+    
+    if (!skipExpire) {
+      _this._setExpiration(key, callback, true);
     }
     else {
-      if (!skipExpire) {
-        _this.setExpiration(key);
-      }
       callback(true);
     }
   });
 };
 
-// Expire a key in expire time if set
-RedisDocumentStore.prototype.setExpiration = function(key) {
-  if (this.expire) {
-    RedisDocumentStore.client.expire(key, this.expire, function(err, reply) {
-      if (err) {
-        winston.error('failed to set expiry on key: ' + key);
-      }
-    });
-  }
-};
-
-// Get a file from a key
 RedisDocumentStore.prototype.get = function(key, callback, skipExpire) {
   var _this = this;
-  RedisDocumentStore.client.get(key, function(err, reply) {
-    if (!err && !skipExpire) {
-      _this.setExpiration(key);
+  RedisDocumentStore.client.mget('info.'+key, 'data.'+key).then(function(reply) {
+    if (!reply) {
+      callback(false);
+      return;
     }
-    callback(err ? false : reply);
+    else {
+      for (var i=0; i<reply.length; i++) {
+        if (reply[i] == null) {
+          callback(false)
+          return;
+        }
+      }
+    }
+
+    if (!skipExpire) {
+      _this._setExpiration(key, callback, reply);
+    }
+    else {
+      callback(reply);
+    }
+  });
+};
+
+RedisDocumentStore.prototype._setExpiration = function(key, callback, callbackValue) {
+  var _this = this;
+  if (!_this.expire) {
+    callback(callbackValue);
+    return;
+  }
+  RedisDocumentStore.client.expire('info.'+key, _this.expire).then(function(reply) {
+    if (!reply) {
+      winston.error('failed to set expiry on key', { key: 'info'+key });
+      callback(false);
+      return;
+    }
+    RedisDocumentStore.client.expire('data.'+key, _this.expire).then(function(reply) {
+      if (!reply) {
+        winston.error('failed to set expiry on key', { key: 'data.'+key });
+        callback(false);
+        return;
+      }
+      callback(callbackValue);
+    });
   });
 };
 


### PR DESCRIPTION
Updating the datastores to handle adding additional metadata. Only redis now stores the metadata. The redis storage now stores two entries per file, a 'info.key' for the metadata, and 'data.key' for the file contents. Closes #34 
