### PR TITLE
Fix connect-route dependency not resolving

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "winston": "0.7.3",
     "connect": "3.1.1",
-    "connect-route": "git://github.com/neandrake/connect-route.git#bc44be0fac3e7ccda51221c07b428a5f3594bd06",
+    "connect-route": "*",
     "st": "0.5.1",
     "then-redis": "0.3.12",
     "uglify-js": "2.4.15",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "winston": "0.7.3",
     "connect": "3.1.1",
-    "connect-route": "*",
+    "connect-route": "0.1.5",
     "st": "0.5.1",
     "then-redis": "0.3.12",
     "uglify-js": "2.4.15",


### PR DESCRIPTION
At some point in the past, package.json contained a dependency to a personal fork of
connect-route that fixed a bug. The bug has since been fixed upstream and the fork
deleted, so "npm install" threw an error message stating that it couldn't find
the repository.

This commit changes the connect-route dependency to "*" so that it simply pulls in
the latest official version of connect-route.